### PR TITLE
Remove unused CAMERON enum entry

### DIFF
--- a/HoldetTeamCoach/PlayerCountry.cs
+++ b/HoldetTeamCoach/PlayerCountry.cs
@@ -12,7 +12,6 @@ namespace HoldetTeamCoach
         FRANCE,
         BRASIL,
         DENMARK,
-        CAMERON,
         ARGENTINA,
         USA,
         ITALY,


### PR DESCRIPTION
## Summary
- clean up PlayerCountry enumeration

## Testing
- `grep -R "CAMERON" -n .`